### PR TITLE
Update to Dart 3 (null safety) (Fix #2)

### DIFF
--- a/built_path/README.md
+++ b/built_path/README.md
@@ -28,12 +28,7 @@ Path get _$diagonalLine => __$diagonalLine ??
 ```
 
 Note that for a Flutter project, you'll have to run
-`flutter packages pub run build_runner build`. Follow https://github.com/flutter/flutter/issues/13360,
-as this syntax may change in a future version of Flutter.
-
-Also note that there will be an error reported about `dart:ui` until
-https://github.com/dart-lang/build/issues/733 is resolved, but the code should
-still get generated.
+`dart run build_runner build`.
 
 The `example/` folder contains a full working example for Flutter, including 
 the `build.yaml` and generated code.

--- a/built_path/example/lib/main.dart
+++ b/built_path/example/lib/main.dart
@@ -15,13 +15,13 @@ class MyApp extends StatelessWidget {
       theme: new ThemeData(
         primarySwatch: Colors.blue,
       ),
-      home: new MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
   }
 }
 
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({Key key, this.title}) : super(key: key);
+  const MyHomePage({super.key, required this.title});
   final String title;
 
   @SvgPath('M20,30 Q40,5 60,30 T100,30')

--- a/built_path/example/lib/main.svg_path.g.dart
+++ b/built_path/example/lib/main.svg_path.g.dart
@@ -7,7 +7,7 @@ part of 'main.dart';
 // SvgPathGenerator
 // **************************************************************************
 
-Path __$MyHomePage_path;
+Path? __$MyHomePage_path;
 Path get _$MyHomePage_path =>
     __$MyHomePage_path ??
     (__$MyHomePage_path = new Path()
@@ -16,7 +16,7 @@ Path get _$MyHomePage_path =>
           13.333333333333332, 60.0, 30.0)
       ..cubicTo(73.33333333333333, 46.666666666666664, 86.66666666666666,
           46.666666666666664, 100.0, 30.0));
-Path __$MyHomePage_star;
+Path? __$MyHomePage_star;
 Path get _$MyHomePage_star =>
     __$MyHomePage_star ??
     (__$MyHomePage_star = new Path()

--- a/built_path/example/pubspec.yaml
+++ b/built_path/example/pubspec.yaml
@@ -10,7 +10,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   built_path:
@@ -22,7 +22,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.5
 
 dev_dependencies:
   build_runner: ^2.1.4

--- a/built_path/lib/src/flutter_path_proxy.dart
+++ b/built_path/lib/src/flutter_path_proxy.dart
@@ -1,12 +1,9 @@
 import 'package:path_parsing/path_parsing.dart';
 
 class FlutterPathGenProxy extends PathProxy {
-  FlutterPathGenProxy() {
-    code = new StringBuffer();
-    code.write('new Path()');
-  }
-
-  StringBuffer code;
+  StringBuffer code =
+    StringBuffer()
+      ..write('new Path()');
 
   @override
   void close() {

--- a/built_path/pubspec.yaml
+++ b/built_path/pubspec.yaml
@@ -8,11 +8,11 @@ author: Dan Field <dfield@gmail.com>
 homepage: https://github.com/dnfield/flutter_built_path
 
 environment:
-  sdk: '>=2.0.0-dev <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   # flutter: ">=0.5.1 <2.0.0"
     
 dependencies:
-  analyzer: ^2.7.0
+  analyzer: ^5.13.0
   build: ^2.1.1
   built_path_annotations: ^0.1.0
   # built_path_annotations:

--- a/built_path/test/src/simple_example.svg_path.g.dart
+++ b/built_path/test/src/simple_example.svg_path.g.dart
@@ -7,14 +7,14 @@ part of 'simple_example.dart';
 // SvgPathGenerator
 // **************************************************************************
 
-Path __$path;
+Path? __$path;
 Path get _$path =>
     __$path ??
     (__$path = new Path()
       ..moveTo(10.0, 10.0)
       ..lineTo(20.0, 20.0)
       ..close());
-Path __$star;
+Path? __$star;
 Path get _$star =>
     __$star ??
     (__$star = new Path()
@@ -25,7 +25,7 @@ Path get _$star =>
       ..lineTo(177.0, 301.0)
       ..close()
       ..fillType = PathFillType.evenOdd);
-Path __$Paths_anotherPath;
+Path? __$Paths_anotherPath;
 Path get _$Paths_anotherPath =>
     __$Paths_anotherPath ??
     (__$Paths_anotherPath = new Path()

--- a/built_path_annotations/pubspec.yaml
+++ b/built_path_annotations/pubspec.yaml
@@ -8,7 +8,7 @@ author: Dan Field <dfield@gmail.com>
 homepage: https://github.com/dnfield/flutter_built_path
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   # flutter: ">=0.5.1 <2.0.0"
     
 # dependencies:


### PR DESCRIPTION
Notes:
* `build_path/pubspec.yaml` needs to point to point to `../built_path_annotations` by path to build until a new version is on pub
* Lower dart sdk versions than 3.0.0 might work too but I did not test them